### PR TITLE
Add program generation for random, lamport and peterson programs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["parser", "interpreter", "ast", "aeg"]
+members = ["parser", "interpreter", "ast", "aeg", "generator"]
 resolver = "2"
 
 # These modules are automatically included in eg `cargo doc` and `cargo test` instead of having to pass --workspace

--- a/aeg/src/aeg.rs
+++ b/aeg/src/aeg.rs
@@ -413,6 +413,10 @@ fn handle_condition(
             handle_expression(graph, reads, e1, globals, thread.clone());
             handle_expression(graph, reads, e2, globals, thread);
         }
+        CondExpr::Leq(e1, e2) => {
+            handle_expression(graph, reads, e1, globals, thread.clone());
+            handle_expression(graph, reads, e2, globals, thread);
+        }
     }
 }
 

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -25,14 +25,23 @@
 //! }
 //! ```
 
+use std::fmt::Display;
+
 /// The type of a variable name in *toy*
 pub type Name = String;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Expr {
+    Num(u32),
+    Var(Name),
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CondExpr {
     Neg(Box<CondExpr>),
     And(Box<CondExpr>, Box<CondExpr>),
     Eq(Expr, Expr),
+    Leq(Expr, Expr),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,6 +57,7 @@ pub enum LogicExpr {
     Neg(Box<LogicExpr>),
     And(Box<LogicExpr>, Box<LogicExpr>),
     Eq(LogicInt, LogicInt),
+    Leq(LogicInt, LogicInt),
 }
 
 /// Four types of fences as defined in figure 7 of Alglave et al., 2017.
@@ -63,12 +73,6 @@ pub enum FenceType {
     RW,
     /// Read-Read fence does not exist in x86 and exists in Power as `sync`, `lwsync`, `dp` or `isync`
     RR,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Expr {
-    Num(u32),
-    Var(Name),
 }
 
 /// A statement in `init` in *toy*
@@ -117,4 +121,153 @@ pub struct Program {
     pub assert: Vec<LogicExpr>,
     /// Global variables that are shared between threads, all other variables are thread local
     pub global_vars: Vec<Name>,
+}
+
+/// Trait for formatting *toy* programs
+trait Formatter {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, indent: usize) -> std::fmt::Result;
+}
+
+impl Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expr::Num(n) => write!(f, "{n}"),
+            Expr::Var(x) => write!(f, "{x}"),
+        }
+    }
+}
+
+impl Display for CondExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CondExpr::Neg(e) => write!(f, "!({e})"),
+            CondExpr::And(e1, e2) => write!(f, "({e1}) && ({e2})"),
+            CondExpr::Eq(e1, e2) => write!(f, "{e1} == {e2}"),
+            CondExpr::Leq(e1, e2) => write!(f, "{e1} <= {e2}"),
+        }
+    }
+}
+
+impl Display for LogicInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogicInt::Num(n) => write!(f, "{n}"),
+            LogicInt::LogicVar(x, y) => write!(f, "{x}.{y}"),
+        }
+    }
+}
+
+impl Display for LogicExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogicExpr::Neg(e) => write!(f, "!({e})"),
+            LogicExpr::And(e1, e2) => write!(f, "({e1}) && ({e2})"),
+            LogicExpr::Eq(e1, e2) => write!(f, "{e1} == {e2}"),
+            LogicExpr::Leq(e1, e2) => write!(f, "{e1} <= {e2}"),
+        }
+    }
+}
+
+impl Display for FenceType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FenceType::WR => write!(f, "WR"),
+            FenceType::WW => write!(f, "WW"),
+            FenceType::RW => write!(f, "RW"),
+            FenceType::RR => write!(f, "RR"),
+        }
+    }
+}
+
+impl Formatter for Init {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, indent: usize) -> std::fmt::Result {
+        match self {
+            Init::Assign(name, expr) => write!(f, "{:indent$}let {name}: u32 = {expr};", "", indent = indent)
+        }
+    }
+}
+
+impl Display for Init {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.format(f, 0)
+    }
+}
+
+impl Formatter for Statement {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, indent: usize) -> std::fmt::Result {
+        match self {
+            Statement::Assign(name, expr) => write!(f, "{:indent$}let {name}: u32 = {expr};", "", indent=indent),
+            Statement::Modify(name, expr) => write!(f, "{:indent$}{name} = {expr};", "", indent=indent),
+            Statement::Fence(fence) => write!(f, "{:indent$}Fence({fence});", "", indent=indent),
+            Statement::If(cond, thn, els) => {
+                writeln!(f, "{:indent$}if ({cond}) {{", "", indent=indent)?;
+                for stmt in thn {
+                    stmt.format(f, indent + 4)?;
+                    writeln!(f)?;
+                }
+                writeln!(f, "{:indent$}}} else {{", "", indent=indent)?;
+                for stmt in els {
+                    stmt.format(f, indent + 4)?;
+                    writeln!(f)?;
+                }
+                write!(f, "{:indent$}}}", "", indent=indent)
+            }
+            Statement::While(cond, body) => {
+                if body.is_empty() {
+                    write!(f, "{:indent$}while ({cond}) {{}}", "", indent=indent)
+                } else {
+                    writeln!(f, "{:indent$}while ({cond}) {{", "", indent = indent)?;
+                    for stmt in body {
+                        stmt.format(f, indent + 4)?;
+                        writeln!(f)?;
+                    }
+                    write!(f, "{:indent$}}}", "", indent = indent)
+                }
+            }
+        }
+    }
+}
+
+impl Display for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.format(f, 0)
+    }
+}
+
+impl Formatter for Thread {
+    fn format(&self, f: &mut std::fmt::Formatter<'_>, indent: usize) -> std::fmt::Result {
+        writeln!(f, "{:indent$}thread {name} {{", "", name=self.name, indent=indent)?;
+        for stmt in &self.instructions {
+            stmt.format(f, indent + 4)?;
+            writeln!(f)?;
+        }
+        write!(f, "{:indent$}}}", "", indent = indent)
+    }
+}
+
+impl Display for Thread {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.format(f, 0)
+    }
+}
+
+impl Display for Program {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for init in &self.init {
+            init.format(f, 0)?;
+            writeln!(f)?;
+        }
+        writeln!(f)?;
+
+        for thread in &self.threads {
+            thread.format(f, 0)?;
+            write!(f, "\n\n")?;
+        }
+
+        writeln!(f, "final {{")?;
+        for expr in &self.assert {
+            writeln!(f, "    assert( {expr} );")?;
+        }
+        write!(f, "}}")
+    }
 }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "generator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
+ast = { path = "../ast" }
+rand = "0.9.0-alpha.1"

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -1,0 +1,231 @@
+use ast::*;
+use ast::CondExpr::*;
+use ast::Expr::*;
+use ast::Statement::*;
+use rand::{Rng, RngCore, thread_rng};
+
+/// Generates a random program.
+pub fn generate_random_program(
+    num_threads: usize,
+    num_instructions: usize,
+    num_global_variables: usize,
+    max_depth: usize
+) -> Program {
+    generate_random_program_with_rng(num_threads, num_instructions, num_global_variables, max_depth, &mut thread_rng())
+}
+
+pub fn generate_random_program_with_rng<R: RngCore + ?Sized>(
+    num_threads: usize,
+    num_instructions: usize,
+    num_global_variables: usize,
+    max_depth: usize,
+    rng: &mut R
+) -> Program {
+    if num_threads == 0 {
+        panic!("Number of threads must be at least 1.")
+    } else if num_instructions == 0 {
+        panic!("Number of instructions must be at least 1.")
+    } else if num_global_variables == 0 {
+        panic!("Number of global variables must be at least 1.")
+    }
+
+    // Init
+    let mut global_vars = vec![];
+    let mut init = vec![];
+    for i in 0..num_global_variables {
+        global_vars.push(format!("x{}", i));
+        init.push(Init::Assign(format!("x{}", i), Num(0)));
+    }
+
+    // Threads
+    let mut threads = vec![];
+    for i in 0..num_threads {
+        let instructions = generate_random_instructions(num_instructions, num_global_variables, num_global_variables / 2, max_depth, rng);
+        threads.push(Thread {
+            name: format!("t{}", i),
+            instructions,
+        });
+    }
+
+    Program {
+        global_vars,
+        init,
+        threads,
+        assert: vec![],
+    }
+}
+
+fn generate_random_instructions<R: RngCore + ?Sized>(
+    num_instructions: usize,
+    num_global_variables: usize,
+    num_values: usize,
+    max_depth: usize,
+    rng: &mut R
+) -> Vec<Statement> {
+    let mut instructions = vec![];
+    for j in 0..num_instructions {
+        let choice = if max_depth == 0 { rng.gen::<f64>() * 0.8 + 0.2 } else { rng.gen::<f64>() };
+        if choice < 0.1 {
+            // If statement
+            let lhs = generate_random_expression(num_global_variables, num_values, rng);
+            let rhs = Num(generate_random_value(num_values, rng));
+            instructions.push(If(
+                Eq(lhs, rhs),
+                generate_random_instructions(num_instructions / 2, num_global_variables, num_values, max_depth - 1, rng),
+                generate_random_instructions(num_instructions / 2, num_global_variables, num_values, max_depth - 1, rng),
+            ));
+        } else if choice < 0.2 {
+            // While statement
+            let lhs = generate_random_expression(num_global_variables, num_values, rng);
+            let rhs = Num(generate_random_value(num_values, rng));
+            instructions.push(While(
+                Eq(lhs, rhs),
+                generate_random_instructions(num_instructions / 2, num_global_variables, num_values, max_depth - 1, rng),
+            ));
+        } else if choice < 0.6 {
+            // Write global variable
+            let variable = rng.gen_range(0..num_global_variables);
+            let value = generate_random_value(num_values, rng);
+            instructions.push(Modify(format!("x{}", variable), Num(value)));
+        } else {
+            // Read global variable
+            let variable = rng.gen_range(0..num_global_variables);
+            instructions.push(Assign(format!("y{}", j), Var(format!("x{}", variable))));
+        }
+    }
+
+    instructions
+}
+
+fn generate_random_expression<R: RngCore + ?Sized>(num_global_variables: usize, num_values: usize, rng: &mut R) -> Expr {
+    if rng.gen::<f64>() < 0.5 {
+        Var(generate_random_var(num_global_variables, rng))
+    } else {
+        Num(generate_random_value(num_values, rng))
+    }
+}
+
+fn generate_random_var<R: RngCore + ?Sized>(num_global_variables: usize, rng: &mut R) -> String {
+    format!("x{}", rng.gen_range(0..num_global_variables))
+}
+
+fn generate_random_value<R: RngCore + ?Sized>(num_values: usize, rng: &mut R) -> u32 {
+    rng.gen_range(0..num_values) as u32
+}
+
+/// Generates a lamport program with the given number of threads.
+pub fn generate_lamport_program(num_threads: usize) -> Program {
+    if num_threads < 2 {
+        panic!("Number of threads must be at least 2.")
+    }
+
+    // Init
+    let mut global_vars = vec!["x".to_string(), "y".to_string()];
+    let mut init = vec![
+        Init::Assign("x".to_string(), Num(0)),                                                       // let x: u32 = 0;
+        Init::Assign("y".to_string(), Num(0)),                                                       // let y: u32 = 0;
+    ];
+    for i in 0..num_threads {
+        global_vars.push(format!("b{i}"));
+        init.push(Init::Assign(format!("b{i}"), Num(0)));                                            // b[i] = 0;
+    }
+
+    // Threads
+    let mut threads = vec![];
+    for i in 0..num_threads {
+        let for_loop: Vec<_> = (0..num_threads).map(|j| {                            // for (j = 0; j < num_threads; j++) {
+            While(Eq(Var(format!("b{j}")), Num(1)), vec![])                                          //   while (b[j] == true) {}
+        }).collect();                                                                                // }
+
+        threads.push(Thread {
+            name: format!("t{i}"),
+            instructions: vec![
+                Assign("i".to_string(), Num(i as u32 + 1)),                                          // i = {i + 1};
+                Assign("stop".to_string(), Num(0)),                                                  // stop = false;
+                While(Eq(Var("stop".to_string()), Num(0)), vec![                                     // while (stop == false) {
+                    Modify(format!("b{i}"), Num(1)),                                                 //   b[i] = true;
+                    Modify("x".to_string(), Var("i".to_string())),                                   //   x = i;
+                    If(Neg(Box::new(Eq(Var("y".to_string()), Num(0)))), vec![                        //   if (!(y == 0)) {
+                        Modify(format!("b{i}"), Num(0)),                                             //     b[i] = false;
+                        While(Neg(Box::new(Eq(Var("y".to_string()), Num(0)))), vec![]),              //     while (y != 0) {}
+                    ], vec![                                                                         //   } else {
+                        Modify("y".to_string(), Var("i".to_string())),                               //     y = i;
+                        Assign("a".to_string(), Var("x".to_string())),                               //     a = x;
+                        If(Neg(Box::new(Eq(Var("a".to_string()), Var("i".to_string())))), [          //     if (a != i) {
+                            vec![Modify(format!("b{i}"), Num(0))],                                   //       b[i] = false;
+                            for_loop,                                                                //       {for_loop}
+                            vec![If(Neg(Box::new(Eq(Var("y".to_string()), Var("i".to_string())))), vec![ //   if (y != i) {
+                                While(Neg(Box::new(Eq(Var("y".to_string()), Num(0)))), vec![]),      //         while (y != 0) {}
+                            ], vec![                                                                 //       } else {
+                                Modify("stop".to_string(), Num(1))                                   //         stop = true;
+                            ])],                                                                     //       }
+                        ].concat(), vec![                                                            //     } else {
+                            Modify("stop".to_string(), Num(1))                                       //       stop = true;
+                        ]),                                                                          //     }
+                    ]),                                                                              //   }
+                ]),                                                                                  // }
+                Modify("y".to_string(), Num(0)),                                                     // y = 0;
+                Modify(format!("b{i}"), Num(0)),                                                     // b[0] = false;
+            ]
+        });
+    }
+
+    Program {
+        global_vars,
+        init,
+        threads,
+        assert: vec![],
+    }
+}
+
+/// Generates a peterson program with the given number of threads.
+pub fn generate_peterson_program(num_threads: usize) -> Program {
+    if num_threads < 2 {
+        panic!("Number of threads must be at least 2.")
+    }
+
+    // Init
+    let mut global_vars = vec![];
+    let mut init = vec![];
+    for i in 0..num_threads {
+        global_vars.push(format!("level{}", i));
+        init.push(Init::Assign(format!("level{}", i), Num(0)));
+    }
+    for i in 0..(num_threads - 1) {
+        global_vars.push(format!("lastToEnter{}", i));
+        init.push(Init::Assign(format!("lastToEnter{}", i), Num(0)));
+    }
+
+    // Threads
+    let mut threads = vec![];
+    for i in 0..num_threads {
+        let mut instructions = vec![];
+        for l in 0..(num_threads - 1) {
+            // level[i] = l
+            instructions.push(Modify(format!("level{i}"), Num(l as u32)));
+            // lastToEnter[i] = l
+            instructions.push(Modify(format!("lastToEnter{l}"), Var("i".to_string())));
+
+            // there exists k != i, such that level[k] >= l
+            let exists = Neg(Box::new((0..num_threads).filter(|k| *k != i)
+                .map(|k| Neg(Box::new(Leq(Num(l as u32), Var(format!("level{k}"))))))
+                .reduce(|e1, e2| And(Box::new(e1), Box::new(e2)))
+                .unwrap()));
+
+            // while (lastToEnter[i] == l && exists) {}
+            instructions.push(While(And(Box::new(Eq(Var(format!("lastToEnter{l}")), Num(i as u32))), Box::new(exists)), vec![]));
+        }
+
+        threads.push(Thread {
+            name: format!("t{i}"),
+            instructions
+        });
+    }
+
+    Program {
+        global_vars,
+        init,
+        threads,
+        assert: vec![],
+    }
+}

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -1,0 +1,75 @@
+use std::fs;
+use std::path::PathBuf;
+use clap::{Args, Parser, Subcommand};
+
+#[derive(Args, Debug, Clone)]
+struct RandomArgs {
+    // Number of threads to generate
+    #[arg()]
+    threads: usize,
+
+    // Number of instructions per thread
+    #[arg()]
+    instructions: usize,
+
+    // Number of global variables
+    #[arg()]
+    global_variables: usize,
+
+    // Maximum depth of the instructions
+    #[arg(long, default_value_t = 2)]
+    max_depth: usize,
+}
+
+#[derive(Args, Debug, Clone)]
+struct LamportArgs {
+    // Number of threads to generate
+    #[arg()]
+    threads: usize,
+}
+
+#[derive(Args, Debug, Clone)]
+struct PetersonArgs {
+    // Number of threads to generate
+    #[arg()]
+    threads: usize,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+#[clap(rename_all = "kebab-case")]
+enum Generator {
+    // Random program
+    Random(RandomArgs),
+    // Lamport's algorithm
+    Lamport(LamportArgs),
+    // Peterson's algorithm
+    Peterson(PetersonArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    // Generator for the toy program
+    #[command(subcommand)]
+    generator: Generator,
+
+    // Output path
+    #[arg(short, long, global = true)]
+    output: Option<PathBuf>,
+}
+
+fn main() {
+    let args = Cli::parse();
+
+    let program = match args.generator {
+        Generator::Random(ra) => generator::generate_random_program(ra.threads, ra.instructions, ra.global_variables, ra.max_depth),
+        Generator::Lamport(la) => generator::generate_lamport_program(la.threads),
+        Generator::Peterson(pa) => generator::generate_peterson_program(pa.threads),
+    };
+
+    if let Some(output) = args.output {
+        fs::write(output, program.to_string()).unwrap();
+    } else {
+        println!("{}", program);
+    }
+}

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -278,6 +278,8 @@ fn evaluate_cond_expression(expr: &CondExpr, state: &mut State, thread_name: &st
             evaluate_cond_expression(e1, state, thread_name) && evaluate_cond_expression(e2, state, thread_name),
         CondExpr::Eq(e1, e2) =>
             evaluate_expression(e1, state, thread_name) == evaluate_expression(e2, state, thread_name),
+        CondExpr::Leq(e1, e2) =>
+            evaluate_expression(e1, state, thread_name) <= evaluate_expression(e2, state, thread_name),
     }
 }
 
@@ -301,10 +303,10 @@ fn assert_expr(expr: &LogicExpr, state: &State) -> bool {
             assert_expr(e1, state) && assert_expr(e2, state)
         }
         LogicExpr::Eq(e1, e2) => {
-            let v1 = assert_logic_int(e1, state);
-            let v2 = assert_logic_int(e2, state);
-
-            v1 == v2
+            assert_logic_int(e1, state) == assert_logic_int(e2, state)
+        }
+        LogicExpr::Leq(e1, e2) => {
+            assert_logic_int(e1, state) <= assert_logic_int(e2, state)
         }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -191,12 +191,17 @@ fn parse_cond_atom(pair: pest::iterators::Pair<Rule>) -> CondExpr {
     debug_assert_eq!(pair.as_rule(), Rule::condatom);
 
     let inner_pair = pair.into_inner().next().unwrap();
+    let rule = inner_pair.as_rule();
     match inner_pair.as_rule() {
-        Rule::condeq => {
+        Rule::condeq | Rule::condleq => {
             let mut inner_pairs = inner_pair.into_inner();
             let left = parse_expression(inner_pairs.next().unwrap());
             let right = parse_expression(inner_pairs.next().unwrap());
-            CondExpr::Eq(left, right)
+            match rule {
+                Rule::condeq => CondExpr::Eq(left, right),
+                Rule::condleq => CondExpr::Leq(left, right),
+                _ => unreachable!(),
+            }
         },
         Rule::condneg => {
             let inner_pair = inner_pair.into_inner().next().unwrap();
@@ -241,13 +246,18 @@ fn parse_logic_atom(pair: pest::iterators::Pair<Rule>) -> LogicExpr {
     );
 
     let inner_pair = pair.into_inner().next().unwrap();
-    match inner_pair.as_rule() {
+    let rule = inner_pair.as_rule();
+    match rule {
         // starting with a logicint means we are comparing equality
-        Rule::logiceq => {
+        Rule::logiceq | Rule::logicleq => {
             let mut inner_pairs = inner_pair.into_inner();
             let left = parse_logic_int(inner_pairs.next().unwrap());
             let right = parse_logic_int(inner_pairs.next().unwrap());
-            LogicExpr::Eq(left, right)
+            match rule {
+                Rule::logiceq => LogicExpr::Eq(left, right),
+                Rule::logicleq => LogicExpr::Leq(left, right),
+                _ => unreachable!(),
+            }
         }
         Rule::logicneg => {
             let inner_expr = parse_logic_expr(inner_pair.into_inner().next().unwrap());

--- a/parser/src/toy.pest
+++ b/parser/src/toy.pest
@@ -25,11 +25,13 @@ condatom = {
     condneg
   | condparen
   | condeq
+  | condleq
 }
 
-condneg = { "!" ~ condexpr }
+condneg   = { "!" ~ condexpr }
 condparen = { "(" ~ condexpr ~ ")" }
-condeq = { expr ~ "==" ~ expr }
+condeq    = { expr ~ "==" ~ expr }
+condleq   = { expr ~ "<=" ~ expr }
 
 // '&&' has lowest precedence
 condexpr = { condatom ~ ("&&" ~ condatom)* }
@@ -38,10 +40,12 @@ logicatom  =  {
     logicneg
   | logicparen
   | logiceq
+  | logicleq
 }
-logicneg = { "!" ~ logicexpr }
+logicneg   = { "!" ~ logicexpr }
 logicparen = { "(" ~ logicexpr ~ ")" }
-logiceq = { logicint ~ "==" ~ logicint }
+logiceq    = { logicint ~ "==" ~ logicint }
+logicleq   = { logicint ~ "<=" ~ logicint }
 
 // '&&' has lowest precedence
 logicexpr = { logicatom ~ ("&&" ~ logicatom)* }


### PR DESCRIPTION
This pr implements 3 different generators for programs:
- The random generator generates a random program following the settings
- The lamport generator generates a lamport program with the specified number of threads
- The peterson generator generates a peterson program with the specified number of threads

The pr also adds support for the <= operator.

I wasn't able to implement barrier because we don't have read-modify-writes and addition implemented.